### PR TITLE
Fix an issue that this addon blocks other PlayerFootstep hooks.

### DIFF
--- a/lua/aperture/paint.lua
+++ b/lua/aperture/paint.lua
@@ -451,7 +451,7 @@ hook.Add("Think", "TA:HandlingPaint", function()
 end)
 
 hook.Add("PlayerFootstep", "TA:Paint_Footsteps", function(ply, pos, foot, lsound, volume)
-	if not ply.TA_LastPaintType then return ply, pos, foot, lsound, volume end
+	if not ply.TA_LastPaintType then return end
 	local orientation 	= ply:GetNWVector("TA:Orientation")
 	local playerHeight 	= ply:GetModelRadius()
 	


### PR DESCRIPTION
Hello.  I love this addon and thank you for making and updating it.
I'm making an addon which uses GM:PlayerFootstep hook and I've found that my hook doesn't run on serverside when this addon is mounted.

To confirm, I've tested as follows in singleplayer:
* Mount [Rebel/Combine/Metrocop Footsteps](http://steamcommunity.com/sharedfiles/filedetails/?id=504310159), then try to hear custom footsteps.
        - Without TA: Heard the custom sounds.
        - With TA: Always heard the normal sounds.
* Type `sv_cheats 1; lua_run hook.Add("PlayerFootstep", "test", function() print "test footstep" end)` in console and walk around.
        - Without TA: "test footstep" was shown in console every time I heard footsteps.
        - With TA: Console didn't print it.
* Type `sv_cheats 1; lua_run_cl hook.Add("PlayerFootstep", "test", function() print "test footstep" end)` in console and walk around.
        - Without TA: Nothing was printed.
        - With TA: Nothing was printed.

Wiki says returning any value other than nil in a hook prevents other hooks from running.  So this hook should return no value instead of all arguments.